### PR TITLE
Hotfix Chrome 89 breadcrumb, pager rendering issue

### DIFF
--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -32,7 +32,7 @@
   </div>
 </div>
 
-<div class="col-md-12">
+<div class="row col-md-12">
   <%= render 'breadcrumbs', facet_list: facet_list, search_params: search_params %>
 </div>
 


### PR DESCRIPTION
Chrome 89 started breaking search results content flow under some conditions. This is mostly a workaround but does correct the issue.