### PR TITLE
On deploy, prompt with a menu of tags

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,6 +4,18 @@ lock "~> 3.11.0"
 set :application, "umedia"
 set :repo_url, "https://github.com/UMNLibraries/umedia.git"
 
+# Retrieve a list of tags to prompt the user for a tag to deploy,
+# sorted by version and defaulting to the latest
+#
+# Skip the prompt by supplying a tag in env $UMEDIA_RELEASE
+# Any branch name or commit hash can also be used instead of a tag
+# e.g. UMEDIA_RELEASE=develop bundle exec cap staging deploy
+# e.g. UMEDIA_RELEASE=v0.10.1 bundle exec cap production deploy
+unless ARGV.include?('deploy:rollback')
+  avail_tags = `git ls-remote --sort=version:refname --refs --tags #{repo_url} | cut -d/ -f3-`
+  set :branch, (ENV['UMEDIA_RELEASE'] || ask("release tag or branch:\n #{avail_tags}", avail_tags.chomp.split("\n").last))
+end
+
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -4,4 +4,3 @@ set :use_sudo, false
 set :rails_env, "production"
 set :bundle_flags, '--deployment'
 set :keep_releases, 3
-set :branch, 'v0.10.1'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -4,7 +4,6 @@ set :use_sudo, false
 set :rails_env, "production"
 set :bundle_flags, '--deployment'
 set :keep_releases, 2
-set :branch, 'develop'
 
 
 # Don't set cron tasks for staging. Everything (indexing, solr backup, etc)


### PR DESCRIPTION
Adds a prompt in Capistrano deploy listing available release tags and defaulting to the most recent by version sort. This simplifies the old prod deploy procedure of specifying a tag in config/deploy/production.rb which could easily fall out of sync between branches.

The tag/branch prompt can be skipped/automated by supplying `$UMEDIA_RELEASE`, e.g.

```
UMEDIA_RELEASE=develop bundle exec cap staging deploy
UMEDIA_RELEASE=v0.10.0 bundle exec cap staging deploy
```

The prompt renders in the shell as
```
Please enter release tag or branch:
 v0.1.0
v0.2.0
v0.3.0
v0.4.0
v0.5.0
v0.6.0
v0.7.0
v0.8.0
v0.9.0
v0.9.1
v0.9.2
v0.10.0
v0.10.1
 (v0.10.1):
```
where the selected default is in `()` and you can press return to accept it.