### PR TITLE
Fixes child page search highlight behavior on numeric strings

### DIFF
--- a/app/helpers/child_searches_helper.rb
+++ b/app/helpers/child_searches_helper.rb
@@ -31,7 +31,7 @@ module ChildSearchesHelper
   end
 
   def highlighter(field, label)
-    return unless field.length > 0
+    return unless field && field.length > 0
     '<div class="highlight">' +
     "<div class=\"highlight-label\">#{label}:</div>" +
     "<div class=\"highlight-data\">#{field.join('...')}</div>" +

--- a/app/lib/umedia/child_search.rb
+++ b/app/lib/umedia/child_search.rb
@@ -62,7 +62,7 @@ module Umedia
       search_config.to_h.merge(
         hl: 'on',
         sort: 'child_index asc',
-        'hl.method': 'unified',
+        'hl.method': 'original',
         fq: search_config.fq + default_fq
       )
     end

--- a/test/integration/large_compound_image_test.rb
+++ b/test/integration/large_compound_image_test.rb
@@ -17,7 +17,7 @@ class HomeTest < ActiveSupport::TestCase
     visit 'item/p16022coll345:69542'
     fill_in 'q', with: 'Genetics'
     find(:xpath, '//*[@id="sidebar"]/form/div/span/button').click
-    _(find(:xpath, '//*[@id="sidebar-p16022coll345:69197"]/div[2]/div[2]').text).must_equal "Committee on Genetics and Society Forum on the Green Revolution XIII International Congress of Genetics, August 21, 1973 World hunger has three causes: agricultural underproduction, the predominance of corporate models of development and distribution, and the economic dependence of the developing nations."
+    _(find(:xpath, '//*[@id="sidebar-p16022coll345:69197"]/div[2]/div[2]').text).must_equal "Committee on Genetics and Society Forum on the Green Revolution XIII International Congress"
     # Page 2 doesn't show up for this search result
     _(has_selector?(:xpath, '//*[@id="sidebar-p16022coll345:69195"]/div')).must_equal false
 

--- a/test/lib/umedia/child_search_test.rb
+++ b/test/lib/umedia/child_search_test.rb
@@ -13,7 +13,7 @@ module Umedia
       solr = mock()
       client.expects(:new).returns(response)
       response.expects(:solr).returns(solr)
-      search_params = {:q=>"", :sort=>"child_index asc", :hl=>"on", :fl=>"title, id, object, parent_id, first_viewer_type, viewer_type, child_index", :"hl.method"=>"unified", :fq=>["parent_id:\"9942\""]}
+      search_params = {:q=>"", :sort=>"child_index asc", :hl=>"on", :fl=>"title, id, object, parent_id, first_viewer_type, viewer_type, child_index", :"hl.method"=>"original", :fq=>["parent_id:\"9942\""]}
       solr.expects(:paginate)
         .with(1, 3, "child_search", {:params=>search_params})
         .returns({'highlighting' => 'highlighting here', 'response' => { 'numFound' => 1, 'docs' =>[{id: 'sdfsdf:sdf'}]}})


### PR DESCRIPTION
Updates complex object child search to use regressive `hl.method=original` instead of the new `unified` highlighter, since the former throws exceptions when doing numeric searches. The default output changes slightly, with a shorter sample string displayed in the child page search results.